### PR TITLE
Migrate block parsing code from go-ouroboros-network

### DIFF
--- a/allegra.go
+++ b/allegra.go
@@ -1,0 +1,34 @@
+package ledger
+
+import (
+	"github.com/fxamacker/cbor/v2"
+)
+
+const (
+	BLOCK_TYPE_ALLEGRA = 3
+
+	BLOCK_HEADER_TYPE_ALLEGRA = 2
+
+	TX_TYPE_ALLEGRA = 2
+)
+
+type AllegraBlock struct {
+	// Tells the CBOR decoder to convert to/from a struct and a CBOR array
+	_                      struct{} `cbor:",toarray"`
+	Header                 ShelleyBlockHeader
+	TransactionBodies      []AllegraTransaction
+	TransactionWitnessSets []ShelleyTransactionWitnessSet
+	// TODO: figure out how to parse properly
+	// We use RawMessage here because the content is arbitrary and can contain data that
+	// cannot easily be represented in Go (such as maps with bytestring keys)
+	TransactionMetadataSet map[uint]cbor.RawMessage
+}
+
+func (b *AllegraBlock) Id() string {
+	return b.Header.Id()
+}
+
+type AllegraTransaction struct {
+	ShelleyTransaction
+	ValidityIntervalStart uint64 `cbor:"8,keyasint,omitempty"`
+}

--- a/alonzo.go
+++ b/alonzo.go
@@ -1,0 +1,48 @@
+package ledger
+
+import (
+	"github.com/fxamacker/cbor/v2"
+)
+
+const (
+	BLOCK_TYPE_ALONZO = 5
+
+	BLOCK_HEADER_TYPE_ALONZO = 4
+
+	TX_TYPE_ALONZO = 4
+)
+
+type AlonzoBlock struct {
+	// Tells the CBOR decoder to convert to/from a struct and a CBOR array
+	_                      struct{} `cbor:",toarray"`
+	Header                 ShelleyBlockHeader
+	TransactionBodies      []AlonzoTransaction
+	TransactionWitnessSets []AlonzoTransactionWitnessSet
+	// TODO: figure out how to parse properly
+	// We use RawMessage here because the content is arbitrary and can contain data that
+	// cannot easily be represented in Go (such as maps with bytestring keys)
+	TransactionMetadataSet map[uint]cbor.RawMessage
+	InvalidTransactions    []uint
+}
+
+func (b *AlonzoBlock) Id() string {
+	return b.Header.Id()
+}
+
+type AlonzoTransaction struct {
+	MaryTransaction
+	ScriptDataHash  Blake2b256                `cbor:"11,keyasint,omitempty"`
+	Collateral      []ShelleyTransactionInput `cbor:"13,keyasint,omitempty"`
+	RequiredSigners []Blake2b224              `cbor:"14,keyasint,omitempty"`
+	NetworkId       uint8                     `cbor:"15,keyasint,omitempty"`
+}
+
+type AlonzoTransactionWitnessSet struct {
+	ShelleyTransactionWitnessSet
+	PlutusScripts interface{} `cbor:"3,keyasint,omitempty"`
+	// TODO: figure out how to parse properly
+	// We use RawMessage here because the content is arbitrary and can contain data that
+	// cannot easily be represented in Go (such as maps with bytestring keys)
+	PlutusData []cbor.RawMessage `cbor:"4,keyasint,omitempty"`
+	Redeemers  []cbor.RawMessage `cbor:"5,keyasint,omitempty"`
+}

--- a/babbage.go
+++ b/babbage.go
@@ -1,0 +1,74 @@
+package ledger
+
+import (
+	"github.com/fxamacker/cbor/v2"
+)
+
+const (
+	BLOCK_TYPE_BABBAGE = 6
+
+	BLOCK_HEADER_TYPE_BABBAGE = 5
+
+	TX_TYPE_BABBAGE = 5
+)
+
+type BabbageBlock struct {
+	// Tells the CBOR decoder to convert to/from a struct and a CBOR array
+	_                      struct{} `cbor:",toarray"`
+	Header                 BabbageBlockHeader
+	TransactionBodies      []BabbageTransaction
+	TransactionWitnessSets []AlonzoTransactionWitnessSet
+	// TODO: figure out how to parse properly
+	// We use RawMessage here because the content is arbitrary and can contain data that
+	// cannot easily be represented in Go (such as maps with bytestring keys)
+	TransactionMetadataSet map[uint]cbor.RawMessage
+	InvalidTransactions    []uint
+}
+
+func (b *BabbageBlock) Id() string {
+	return b.Header.Id()
+}
+
+type BabbageBlockHeader struct {
+	// Tells the CBOR decoder to convert to/from a struct and a CBOR array
+	_    struct{} `cbor:",toarray"`
+	id   string
+	Body struct {
+		// Tells the CBOR decoder to convert to/from a struct and a CBOR array
+		_             struct{} `cbor:",toarray"`
+		BlockNumber   uint64
+		Slot          uint64
+		PrevHash      Blake2b256
+		IssuerVkey    interface{}
+		VrfKey        interface{}
+		VrfResult     interface{}
+		BlockBodySize uint32
+		BlockBodyHash Blake2b256
+		OpCert        struct {
+			// Tells the CBOR decoder to convert to/from a struct and a CBOR array
+			_              struct{} `cbor:",toarray"`
+			HotVkey        interface{}
+			SequenceNumber uint32
+			KesPeriod      uint32
+			Signature      interface{}
+		}
+		ProtoVersion struct {
+			// Tells the CBOR decoder to convert to/from a struct and a CBOR array
+			_     struct{} `cbor:",toarray"`
+			Major uint64
+			Minor uint64
+		}
+	}
+	Signature interface{}
+}
+
+func (h *BabbageBlockHeader) Id() string {
+	return h.id
+}
+
+type BabbageTransaction struct {
+	AlonzoTransaction
+	CollateralReturn ShelleyTransactionOutput  `cbor:"16,keyasint,omitempty"`
+	TotalCollateral  uint64                    `cbor:"17,keyasint,omitempty"`
+	ReferenceInputs  []ShelleyTransactionInput `cbor:"18,keyasint,omitempty"`
+}

--- a/block.go
+++ b/block.go
@@ -1,0 +1,140 @@
+package ledger
+
+import (
+	"encoding/hex"
+	"fmt"
+	"github.com/fxamacker/cbor/v2"
+	"golang.org/x/crypto/blake2b"
+)
+
+type Blake2b256 [32]byte
+
+func (b Blake2b256) String() string {
+	return hex.EncodeToString([]byte(b[:]))
+}
+
+type Blake2b224 [28]byte
+
+func (b Blake2b224) String() string {
+	return hex.EncodeToString([]byte(b[:]))
+}
+
+func NewBlockFromCbor(blockType uint, data []byte) (interface{}, error) {
+	var err error
+	// Parse outer list to get at header CBOR
+	var rawBlock []cbor.RawMessage
+	if err := cbor.Unmarshal(data, &rawBlock); err != nil {
+		return nil, err
+	}
+	switch blockType {
+	case BLOCK_TYPE_BYRON_EBB:
+		var byronEbbBlock ByronEpochBoundaryBlock
+		if err := cbor.Unmarshal(data, &byronEbbBlock); err != nil {
+			return nil, fmt.Errorf("chain-sync: decode error: %s", err)
+		}
+		// Prepend bytes for CBOR list wrapper
+		// The block hash is calculated with these extra bytes, so we have to add them to
+		// get the correct value
+		byronEbbBlock.Header.id, err = generateBlockHeaderHash(rawBlock[0], []byte{0x82, BLOCK_TYPE_BYRON_EBB})
+		return &byronEbbBlock, err
+	case BLOCK_TYPE_BYRON_MAIN:
+		var byronMainBlock ByronMainBlock
+		if err := cbor.Unmarshal(data, &byronMainBlock); err != nil {
+			return nil, fmt.Errorf("chain-sync: decode error: %s", err)
+		}
+		// Prepend bytes for CBOR list wrapper
+		// The block hash is calculated with these extra bytes, so we have to add them to
+		// get the correct value
+		byronMainBlock.Header.id, err = generateBlockHeaderHash(rawBlock[0], []byte{0x82, BLOCK_TYPE_BYRON_MAIN})
+		return &byronMainBlock, err
+	case BLOCK_TYPE_SHELLEY:
+		var shelleyBlock ShelleyBlock
+		if err := cbor.Unmarshal(data, &shelleyBlock); err != nil {
+			return nil, fmt.Errorf("chain-sync: decode error: %s", err)
+		}
+		shelleyBlock.Header.id, err = generateBlockHeaderHash(rawBlock[0], nil)
+		return &shelleyBlock, err
+	case BLOCK_TYPE_ALLEGRA:
+		var allegraBlock AllegraBlock
+		if err := cbor.Unmarshal(data, &allegraBlock); err != nil {
+			return nil, fmt.Errorf("chain-sync: decode error: %s", err)
+		}
+		allegraBlock.Header.id, err = generateBlockHeaderHash(rawBlock[0], nil)
+		return &allegraBlock, err
+	case BLOCK_TYPE_MARY:
+		var maryBlock MaryBlock
+		if err := cbor.Unmarshal(data, &maryBlock); err != nil {
+			return nil, fmt.Errorf("chain-sync: decode error: %s", err)
+		}
+		maryBlock.Header.id, err = generateBlockHeaderHash(rawBlock[0], nil)
+		return &maryBlock, err
+	case BLOCK_TYPE_ALONZO:
+		var alonzoBlock AlonzoBlock
+		if err := cbor.Unmarshal(data, &alonzoBlock); err != nil {
+			return nil, fmt.Errorf("chain-sync: decode error: %s", err)
+		}
+		alonzoBlock.Header.id, err = generateBlockHeaderHash(rawBlock[0], nil)
+		return &alonzoBlock, err
+	case BLOCK_TYPE_BABBAGE:
+		var babbageBlock BabbageBlock
+		if err := cbor.Unmarshal(data, &babbageBlock); err != nil {
+			return nil, fmt.Errorf("chain-sync: decode error: %s", err)
+		}
+		babbageBlock.Header.id, err = generateBlockHeaderHash(rawBlock[0], nil)
+		return &babbageBlock, err
+	}
+	return nil, fmt.Errorf("unknown node-to-client block type: %d", blockType)
+}
+
+func NewBlockHeaderFromCbor(blockType uint, data []byte) (interface{}, error) {
+	var err error
+	switch blockType {
+	case BLOCK_TYPE_BYRON_EBB:
+		var byronEbbBlockHeader ByronEpochBoundaryBlockHeader
+		if err := cbor.Unmarshal(data, &byronEbbBlockHeader); err != nil {
+			return nil, fmt.Errorf("chain-sync: decode error: %s", err)
+		}
+		// Prepend bytes for CBOR list wrapper
+		// The block hash is calculated with these extra bytes, so we have to add them to
+		// get the correct value
+		byronEbbBlockHeader.id, err = generateBlockHeaderHash(data, []byte{0x82, BLOCK_TYPE_BYRON_EBB})
+		return &byronEbbBlockHeader, err
+	case BLOCK_TYPE_BYRON_MAIN:
+		var byronMainBlockHeader ByronMainBlockHeader
+		if err := cbor.Unmarshal(data, &byronMainBlockHeader); err != nil {
+			return nil, fmt.Errorf("chain-sync: decode error: %s", err)
+		}
+		// Prepend bytes for CBOR list wrapper
+		// The block hash is calculated with these extra bytes, so we have to add them to
+		// get the correct value
+		byronMainBlockHeader.id, err = generateBlockHeaderHash(data, []byte{0x82, BLOCK_TYPE_BYRON_MAIN})
+		return &byronMainBlockHeader, err
+	case BLOCK_TYPE_SHELLEY, BLOCK_TYPE_ALLEGRA, BLOCK_TYPE_MARY, BLOCK_TYPE_ALONZO:
+		var shelleyBlockHeader ShelleyBlockHeader
+		if err := cbor.Unmarshal(data, &shelleyBlockHeader); err != nil {
+			return nil, fmt.Errorf("chain-sync: decode error: %s", err)
+		}
+		shelleyBlockHeader.id, err = generateBlockHeaderHash(data, nil)
+		return &shelleyBlockHeader, err
+	case BLOCK_TYPE_BABBAGE:
+		var babbageBlockHeader BabbageBlockHeader
+		if err := cbor.Unmarshal(data, &babbageBlockHeader); err != nil {
+			return nil, fmt.Errorf("chain-sync: decode error: %s", err)
+		}
+		babbageBlockHeader.id, err = generateBlockHeaderHash(data, nil)
+		return &babbageBlockHeader, err
+	}
+	return nil, fmt.Errorf("unknown node-to-node block type: %d", blockType)
+}
+
+func generateBlockHeaderHash(data []byte, prefix []byte) (string, error) {
+	tmpHash, err := blake2b.New256(nil)
+	if err != nil {
+		return "", err
+	}
+	if prefix != nil {
+		tmpHash.Write(prefix)
+	}
+	tmpHash.Write(data)
+	return hex.EncodeToString(tmpHash.Sum(nil)), nil
+}

--- a/byron.go
+++ b/byron.go
@@ -1,0 +1,123 @@
+package ledger
+
+import (
+	"github.com/fxamacker/cbor/v2"
+)
+
+const (
+	BLOCK_TYPE_BYRON_EBB  = 0
+	BLOCK_TYPE_BYRON_MAIN = 1
+
+	BLOCK_HEADER_TYPE_BYRON = 0
+
+	TX_TYPE_BYRON = 0
+)
+
+type ByronMainBlockHeader struct {
+	// Tells the CBOR decoder to convert to/from a struct and a CBOR array
+	_             struct{} `cbor:",toarray"`
+	id            string
+	ProtocolMagic uint32
+	PrevBlock     Blake2b256
+	BodyProof     interface{}
+	ConsensusData struct {
+		// Tells the CBOR decoder to convert to/from a struct and a CBOR array
+		_ struct{} `cbor:",toarray"`
+		// [slotid, pubkey, difficulty, blocksig]
+		SlotId struct {
+			// Tells the CBOR decoder to convert to/from a struct and a CBOR array
+			_     struct{} `cbor:",toarray"`
+			Epoch uint64
+			Slot  uint16
+		}
+		PubKey     []byte
+		Difficulty struct {
+			// Tells the CBOR decoder to convert to/from a struct and a CBOR array
+			_       struct{} `cbor:",toarray"`
+			Unknown uint64
+		}
+		BlockSig []interface{}
+	}
+	ExtraData struct {
+		// Tells the CBOR decoder to convert to/from a struct and a CBOR array
+		_            struct{} `cbor:",toarray"`
+		BlockVersion struct {
+			// Tells the CBOR decoder to convert to/from a struct and a CBOR array
+			_       struct{} `cbor:",toarray"`
+			Major   uint16
+			Minor   uint16
+			Unknown uint8
+		}
+		SoftwareVersion struct {
+			// Tells the CBOR decoder to convert to/from a struct and a CBOR array
+			_       struct{} `cbor:",toarray"`
+			Name    string
+			Unknown uint32
+		}
+		Attributes interface{}
+		ExtraProof Blake2b256
+	}
+}
+
+func (h *ByronMainBlockHeader) Id() string {
+	return h.id
+}
+
+type ByronMainBlockBody struct {
+	// Tells the CBOR decoder to convert to/from a struct and a CBOR array
+	_         struct{} `cbor:",toarray"`
+	TxPayload []interface{}
+	// We keep this field as raw CBOR, since it contains a map with []byte
+	// keys, which Go doesn't allow
+	SscPayload cbor.RawMessage
+	DlgPayload []interface{}
+	UpdPayload []interface{}
+}
+
+type ByronEpochBoundaryBlockHeader struct {
+	// Tells the CBOR decoder to convert to/from a struct and a CBOR array
+	_             struct{} `cbor:",toarray"`
+	id            string
+	ProtocolMagic uint32
+	PrevBlock     Blake2b256
+	BodyProof     interface{}
+	ConsensusData struct {
+		// Tells the CBOR decoder to convert to/from a struct and a CBOR array
+		_          struct{} `cbor:",toarray"`
+		Epoch      uint64
+		Difficulty struct {
+			// Tells the CBOR decoder to convert to/from a struct and a CBOR array
+			_     struct{} `cbor:",toarray"`
+			Value uint64
+		}
+	}
+	ExtraData interface{}
+}
+
+func (h *ByronEpochBoundaryBlockHeader) Id() string {
+	return h.id
+}
+
+type ByronMainBlock struct {
+	// Tells the CBOR decoder to convert to/from a struct and a CBOR array
+	_      struct{} `cbor:",toarray"`
+	Header ByronMainBlockHeader
+	Body   ByronMainBlockBody
+	Extra  []interface{}
+}
+
+func (b *ByronMainBlock) Id() string {
+	return b.Header.Id()
+}
+
+type ByronEpochBoundaryBlock struct {
+	// Tells the CBOR decoder to convert to/from a struct and a CBOR array
+	_      struct{} `cbor:",toarray"`
+	Header ByronEpochBoundaryBlockHeader
+	Body   []Blake2b224
+	Extra  []interface{}
+}
+
+func (b *ByronEpochBoundaryBlock) Id() string {
+	return b.Header.Id()
+}

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,12 @@ module github.com/cloudstruct/go-cardano-ledger
 
 go 1.17
 
-require github.com/fxamacker/cbor/v2 v2.4.0
+require (
+	github.com/fxamacker/cbor/v2 v2.4.0
+	golang.org/x/crypto v0.0.0-20220824171710-5757bc0c5503
+)
 
-require github.com/x448/float16 v0.8.4 // indirect
+require (
+	github.com/x448/float16 v0.8.4 // indirect
+	golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -2,3 +2,13 @@ github.com/fxamacker/cbor/v2 v2.4.0 h1:ri0ArlOR+5XunOP8CRUowT0pSJOwhW098ZCUyskZD
 github.com/fxamacker/cbor/v2 v2.4.0/go.mod h1:TA1xS00nchWmaBnEIxPSE5oHLuJBAVvqrtAnWBwBCVo=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
+golang.org/x/crypto v0.0.0-20220824171710-5757bc0c5503 h1:vJ2V3lFLg+bBhgroYuRfyN583UzVveQmIXjc8T/y3to=
+golang.org/x/crypto v0.0.0-20220824171710-5757bc0c5503/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
+golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
+golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1 h1:SrN+KX8Art/Sf4HNj6Zcz06G7VEz+7w9tdXTPOZ7+l4=
+golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
+golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/mary.go
+++ b/mary.go
@@ -1,0 +1,46 @@
+package ledger
+
+import (
+	"github.com/fxamacker/cbor/v2"
+)
+
+const (
+	BLOCK_TYPE_MARY = 4
+
+	BLOCK_HEADER_TYPE_MARY = 3
+
+	TX_TYPE_MARY = 3
+)
+
+type MaryBlock struct {
+	// Tells the CBOR decoder to convert to/from a struct and a CBOR array
+	_                      struct{} `cbor:",toarray"`
+	Header                 ShelleyBlockHeader
+	TransactionBodies      []MaryTransaction
+	TransactionWitnessSets []ShelleyTransactionWitnessSet
+	// TODO: figure out how to parse properly
+	// We use RawMessage here because the content is arbitrary and can contain data that
+	// cannot easily be represented in Go (such as maps with bytestring keys)
+	TransactionMetadataSet map[uint]cbor.RawMessage
+}
+
+func (b *MaryBlock) Id() string {
+	return b.Header.Id()
+}
+
+type MaryTransaction struct {
+	AllegraTransaction
+	//Outputs []MaryTransactionOutput `cbor:"1,keyasint,omitempty"`
+	Outputs []cbor.RawMessage `cbor:"1,keyasint,omitempty"`
+	// TODO: further parsing of this field
+	Mint cbor.RawMessage `cbor:"9,keyasint,omitempty"`
+}
+
+// TODO: support both forms
+/*
+transaction_output = [address, amount : value]
+value = coin / [coin,multiasset<uint>]
+*/
+//type MaryTransactionOutput interface{}
+
+type MaryTransactionOutput cbor.RawMessage

--- a/shelley.go
+++ b/shelley.go
@@ -1,0 +1,102 @@
+package ledger
+
+import (
+	"github.com/fxamacker/cbor/v2"
+)
+
+const (
+	BLOCK_TYPE_SHELLEY = 2
+
+	BLOCK_HEADER_TYPE_SHELLEY = 1
+
+	TX_TYPE_SHELLEY = 1
+)
+
+type ShelleyBlock struct {
+	// Tells the CBOR decoder to convert to/from a struct and a CBOR array
+	_                      struct{} `cbor:",toarray"`
+	Header                 ShelleyBlockHeader
+	TransactionBodies      []ShelleyTransaction
+	TransactionWitnessSets []ShelleyTransactionWitnessSet
+	// TODO: figure out how to parse properly
+	// We use RawMessage here because the content is arbitrary and can contain data that
+	// cannot easily be represented in Go (such as maps with bytestring keys)
+	TransactionMetadataSet map[uint]cbor.RawMessage
+}
+
+func (b *ShelleyBlock) Id() string {
+	return b.Header.Id()
+}
+
+type ShelleyBlockHeader struct {
+	// Tells the CBOR decoder to convert to/from a struct and a CBOR array
+	_    struct{} `cbor:",toarray"`
+	id   string
+	Body struct {
+		// Tells the CBOR decoder to convert to/from a struct and a CBOR array
+		_                    struct{} `cbor:",toarray"`
+		BlockNumber          uint64
+		Slot                 uint64
+		PrevHash             Blake2b256
+		IssuerVkey           interface{}
+		VrfKey               interface{}
+		NonceVrf             interface{}
+		LeaderVrf            interface{}
+		BlockBodySize        uint32
+		BlockBodyHash        Blake2b256
+		OpCertHotVkey        interface{}
+		OpCertSequenceNumber uint32
+		OpCertKesPeriod      uint32
+		OpCertSignature      interface{}
+		ProtoMajorVersion    uint64
+		ProtoMinorVersion    uint64
+	}
+	Signature interface{}
+}
+
+func (h *ShelleyBlockHeader) Id() string {
+	return h.id
+}
+
+type ShelleyTransaction struct {
+	Inputs  []ShelleyTransactionInput  `cbor:"0,keyasint,omitempty"`
+	Outputs []ShelleyTransactionOutput `cbor:"1,keyasint,omitempty"`
+	Fee     uint64                     `cbor:"2,keyasint,omitempty"`
+	Ttl     uint64                     `cbor:"3,keyasint,omitempty"`
+	// TODO: figure out how to parse properly
+	Certificates []cbor.RawMessage `cbor:"4,keyasint,omitempty"`
+	// TODO: figure out how to parse this correctly
+	// We keep the raw CBOR because it can contain a map with []byte keys, which
+	// Go does not allow
+	Withdrawals cbor.RawMessage `cbor:"5,keyasint,omitempty"`
+	Update      struct {
+		// Tells the CBOR decoder to convert to/from a struct and a CBOR array
+		_ struct{} `cbor:",toarray"`
+		// TODO: figure out how to parse properly
+		// We use RawMessage here because the content is arbitrary and can contain data that
+		// cannot easily be represented in Go (such as maps with bytestring keys)
+		ProtocolParamUpdates cbor.RawMessage
+		Epoch                uint64
+	} `cbor:"6,keyasint,omitempty"`
+	MetadataHash Blake2b256 `cbor:"7,keyasint,omitempty"`
+}
+
+type ShelleyTransactionInput struct {
+	// Tells the CBOR decoder to convert to/from a struct and a CBOR array
+	_     struct{} `cbor:",toarray"`
+	Id    Blake2b256
+	Index uint32
+}
+
+type ShelleyTransactionOutput struct {
+	// Tells the CBOR decoder to convert to/from a struct and a CBOR array
+	_       struct{} `cbor:",toarray"`
+	Address Blake2b256
+	Amount  uint64
+}
+
+type ShelleyTransactionWitnessSet struct {
+	VkeyWitnesses      []interface{} `cbor:"0,keyasint,omitempty"`
+	MultisigScripts    []interface{} `cbor:"1,keyasint,omitempty"`
+	BootstrapWitnesses []interface{} `cbor:"2,keyasint,omitempty"`
+}


### PR DESCRIPTION
There is no new code in this commit. This is a copy of block/ from
go-ouroboros-network with the following changes:

* package name changed to 'ledger'
* common.go renamed to block.go